### PR TITLE
Add basic boilerplate html

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ It is recommended to use a [virtual environment](https://realpython.com/python-v
 
 `pip install -r requirements.txt`
 
+`npm install bootstrap@5.3.0`
+
 ### Running Locally
 
 Run application:

--- a/app/templates/boilerplate.html
+++ b/app/templates/boilerplate.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>{% block title %}{% endblock %}</title>
+    
+    <!-- bootstrap css ref -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
+</head>
+<body>
+    {% block content %}{% endblock %}
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -1,2 +1,9 @@
-<!DOCTYPE html>
+{% extends "boilerplate.html" %}
+
+{% block title %}
+Home Page
+{% endblock %}
+
+{% block content %}
 <h1>CS 467 - Open Source Travel Planner</h1>
+{% endblock %}


### PR DESCRIPTION
Adds basic `boilerplate.html` which includes a reference to bootstraps dependencies, and updates `README.md` to include installation guide for bootstrap `5.3.0`. Also gets `home.html` to start using our boilerplate. 